### PR TITLE
Introduce CMake based build system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 3.11)
+
+project(thunder)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+find_package(Qt5 COMPONENTS Core Gui Widgets Quick QuickWidgets)
+find_package(Threads REQUIRED)
+if(WIN32)
+  add_definitions(-D_UNICODE -DUNICODE)
+endif()
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+# Output all built binaries (exe/dll) to a single directory
+#set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+add_subdirectory(thirdparty)
+
+add_subdirectory(engine)
+add_subdirectory(modules)
+add_subdirectory(worldeditor)
+
+add_subdirectory(builder)

--- a/builder/CMakeLists.txt
+++ b/builder/CMakeLists.txt
@@ -1,0 +1,152 @@
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(SRC_FILES
+    builder.cpp    
+    builder.h
+    consolelog.h
+    main.cpp
+    
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/animconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/assetmanager.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/effectconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/fbxconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/fontconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/functionmodel.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/aconstvalue.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/acoordinates.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/agradient.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/amaterialparam.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/amathfunction.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/amathoperator.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/atexturesample.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/autils.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/materialconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/prefabconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/qbsbuilder.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/shaderbuilder.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/spirvconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/textconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/textureconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/animconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/assetmanager.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/effectconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/fbxconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/fontconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/functionmodel.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/materialconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/prefabconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/qbsbuilder.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/shaderbuilder.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/textconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/textureconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/pluginmanager/include/pluginmodel.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/pluginmanager/src/pluginmodel.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/projectmanager/include/projectmanager.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/projectmanager/include/projectmodel.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/projectmanager/src/projectmanager.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/projectmanager/src/projectmodel.cpp
+    ${PROJECT_SOURCE_DIR}/develop/models/include/abstractschememodel.h
+    ${PROJECT_SOURCE_DIR}/develop/models/include/baseobjectmodel.h
+    ${PROJECT_SOURCE_DIR}/develop/models/src/baseobjectmodel.cpp
+)
+add_executable(builder ${SRC_FILES})
+target_include_directories(builder PRIVATE 
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR} # for config.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include
+    ${PROJECT_SOURCE_DIR}/develop/managers/projectmanager/include
+    ${PROJECT_SOURCE_DIR}/develop/managers/pluginmanager/include
+    ${PROJECT_SOURCE_DIR}/develop/models/include/
+)
+
+target_link_libraries(builder PRIVATE 
+    engine-editor rendergl-editor 
+    Qt5::Core Qt5::Gui
+    fbx glsl spirvcross quazip-editor
+    )
+target_compile_definitions(builder PRIVATE NEXT_SHARED BUILDER)
+target_compile_definitions(builder PUBLIC
+    -DCOMPANY_NAME="FrostSpear"
+    -DEDITOR_NAME="WorldEditor"
+    -DPRODUCT_NAME="Thunder Engine"
+    -DCOPYRIGHT_AUTHOR="Evgeniy Prikazchikov"
+    -DSPONSORS="${SPONSORS}"
+    -DCOPYRIGHT_YEAR="${COPYRIGHT_YEAR}"
+    -DLEGAL="${LEGAL}"
+    -DREVISION="${GIT_BRANCH}"
+    -DBUILDER_NAME="Builder"
+    -DSDK_VERSION="1.0"
+#    LAUNCHER_VERSION = "1.0"
+#    YEAR = 2017
+    )
+
+#Project {
+#    id: builder
+#
+#    property stringList incPaths: [
+#        "src",
+#        "../",
+#        "../common",
+#        "../engine/includes",
+#        "../engine/includes/resources",
+#        "../develop/managers/codemanager/include",
+#        "../develop/managers/projectmanager/include",
+#        "../develop/managers/assetmanager/include",
+#        "../develop/managers/pluginmanager/include",
+#        "../develop/models/include",
+#        "../modules/renders/rendergl/includes",
+#        "../thirdparty/next/inc",
+#        "../thirdparty/next/inc/math",
+#        "../thirdparty/next/inc/core",
+#        "../thirdparty/next/inc/anim",
+#        "../thirdparty/physfs/inc",
+#        "../thirdparty/glfw/inc",
+#        "../thirdparty/fbx/inc",
+#        "../thirdparty/zlib/src",
+#        "../thirdparty/quazip/src",
+#        "../thirdparty/glsl",
+#        "../thirdparty/spirvcross/src"
+#    ]
+#
+#    QtApplication {
+#        name: builder.BUILDER_NAME
+#        condition: builder.desktop
+#        files: builder.srcFiles
+#        Depends { name: "cpp" }
+#        Depends { name: "quazip-editor" }
+#
+#        bundle.isBundle: false
+#
+#        cpp.includePaths: builder.incPaths
+#        cpp.libraryPaths: [
+#            "../thirdparty/fbx/lib"
+#        ]
+#
+#        property string prefix: qbs.targetOS.contains("windows") ? "lib" : ""
+#        cpp.dynamicLibraries: [
+#            prefix + "fbxsdk"
+#        ]
+#        cpp.cxxLanguageVersion: "c++14"
+#
+#        Properties {
+#            condition: qbs.targetOS.contains("linux")
+#            cpp.rpaths: "$ORIGIN"
+#        }
+#
+#        Properties {
+#            condition: qbs.targetOS.contains("darwin")
+#            cpp.sonamePrefix: "@rpath"
+#            cpp.rpaths: "@executable_path/../Frameworks/"
+#        }
+#
+#        Group {
+#            name: "Install " + builder.BUILDER_NAME
+#            fileTagsFilter: product.type
+#            qbs.install: true
+#            qbs.installDir: builder.BIN_PATH + "/" + builder.bundle
+#            qbs.installPrefix: builder.PREFIX
+#        }
+#    }
+#}

--- a/builder/builder.cpp
+++ b/builder/builder.cpp
@@ -3,6 +3,9 @@
 #include "log.h"
 #include "projectmanager.h"
 
+#include <quazip.h>
+#include <quazipfile.h>
+
 #include <QCoreApplication>
 
 Builder::Builder() {

--- a/builder/builder.h
+++ b/builder/builder.h
@@ -4,9 +4,6 @@
 #include <QDirIterator>
 #include <QDebug>
 
-#include <quazip.h>
-#include <quazipfile.h>
-
 class Builder : public QObject {
     Q_OBJECT
 public:

--- a/develop/managers/assetmanager/include/fbxconverter.h
+++ b/develop/managers/assetmanager/include/fbxconverter.h
@@ -1,7 +1,11 @@
 #ifndef FBXCONVERTER_H
 #define FBXCONVERTER_H
 
-#include <fbxsdk.h>
+namespace fbxsdk
+{
+    class FbxNode;
+    class FbxScene;
+}
 
 #include "converters/converter.h"
 
@@ -30,8 +34,8 @@ public:
 
 protected:
     void                        importFBX               (const string &src, Mesh &mesh);
-    void                        importDynamic           (FbxNode *lRootNode, Mesh &mesh);
-    void                        importAFAnimation       (FbxScene *lScene);
+    void                        importDynamic           (fbxsdk::FbxNode *lRootNode, Mesh &mesh);
+    void                        importAFAnimation       (fbxsdk::FbxScene *lScene);
 
     void                        saveAnimation           (const string &dst);
 

--- a/develop/managers/assetmanager/include/material/agradient.h
+++ b/develop/managers/assetmanager/include/material/agradient.h
@@ -6,7 +6,6 @@
 #define X       "X"
 #define Y       "Y"
 #define A       "A"
-#define OUT     "Out"
 #define EDGE1   "Edge1"
 #define EDGE2   "Edge2"
 
@@ -14,6 +13,7 @@ class ASmothCurve : public AObject, public IShaderFunction {
     ACLASS(ASmothCurve)
     AREGISTER(ASmothCurve, Material/Gradient)
 
+    static constexpr const char *OUT ="Out";
 public:
     ASmothCurve() {
         APROPERTY(float,    OUT,      "", 1.0f, AProperty::READ | AProperty::SCHEME,   -1);

--- a/develop/managers/assetmanager/include/material/amathfunction.h
+++ b/develop/managers/assetmanager/include/material/amathfunction.h
@@ -3,8 +3,6 @@
 
 #include "../shaderbuilder.h"
 
-#define A       "A"
-#define B       "B"
 #define MINV    "Min"
 #define MAXV    "Max"
 
@@ -13,6 +11,9 @@ class MathFunction : public ShaderFunction {
     Q_CLASSINFO("Group", "Math")
 
 public:
+    static constexpr const char *A = "A";
+    static constexpr const char *B = "B";
+
     AbstractSchemeModel::Node *createNode(ShaderBuilder *model, const QString &path) {
         AbstractSchemeModel::Node *result   = ShaderFunction::createNode(model, path);
         int i   = 0;

--- a/develop/managers/assetmanager/include/material/amathoperator.h
+++ b/develop/managers/assetmanager/include/material/amathoperator.h
@@ -3,15 +3,15 @@
 
 #include "../shaderbuilder.h"
 
-#define A       "A"
-#define B       "B"
-#define OUT     "Out"
-
 class MathOperation : public ShaderFunction {
     Q_OBJECT
     Q_CLASSINFO("Group", "Operations")
 
 public:
+    static constexpr const char *A = "A";
+    static constexpr const char *B = "B";
+    static constexpr const char *OUT = "Out";
+
     AbstractSchemeModel::Node *createNode(ShaderBuilder *model, const QString &path) {
         AbstractSchemeModel::Node *result   = ShaderFunction::createNode(model, path);
         {
@@ -45,7 +45,7 @@ public:
         if(m_Position == -1) {
             QString args;
 
-            vector<char *> names    = {(char *)A, (char *)B};
+            vector<const char *> names    = {A, B};
 
             const AbstractSchemeModel::Link *l  = nullptr;
 

--- a/develop/managers/assetmanager/include/material/atexturesample.h
+++ b/develop/managers/assetmanager/include/material/atexturesample.h
@@ -6,16 +6,17 @@
 #include "assetmanager.h"
 
 #define UV      "UV"
-#define R       "R"
-#define G       "G"
-#define B       "B"
-#define A       "A"
 
 class TextureFunction : public ShaderFunction {
     Q_OBJECT
     Q_CLASSINFO("Group", "Texture")
 
 public:
+    static constexpr const char *R = "R";
+    static constexpr const char *G = "G";
+    static constexpr const char *B = "B";
+    static constexpr const char *A = "A";
+
     Q_INVOKABLE TextureFunction() { }
 
     virtual AbstractSchemeModel::Node  *createNode  (ShaderBuilder *model, const QString &path) {

--- a/develop/managers/assetmanager/include/material/autils.h
+++ b/develop/managers/assetmanager/include/material/autils.h
@@ -3,7 +3,6 @@
 
 #include <components/material.h>
 
-#define IN  "In"
 #define X   "X"
 #define Y   "Y"
 #define Z   "Z"
@@ -11,6 +10,8 @@
 
 class VectorRutine : public IMaterialObjectGL {
 public:
+    static constexpr const char *IN = "In";
+
     void breakVector(AObject &object, string &value, const AObject::link_data &link, uint32_t &depth, uint8_t &size) {
         size    = AVariant::FLOAT;
 

--- a/develop/managers/assetmanager/src/fbxconverter.cpp
+++ b/develop/managers/assetmanager/src/fbxconverter.cpp
@@ -3,18 +3,16 @@
 #include "resources/mesh.h"
 #include "file.h"
 #include "log.h"
+#include "converters/converter.h"
+#include "projectmanager.h"
 
+#include <fbxsdk.h>
 #include <bson.h>
 
-#if __linux__
 #include <cstring>
-#endif
 
 #include <QFileInfo>
 #include <QTime>
-
-#include "converters/converter.h"
-#include "projectmanager.h"
 
 #define HEADER  "Header"
 #define DATA    "Data"

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,0 +1,101 @@
+include(GenerateExportHeader)
+
+set(SRC_FILES
+    src/analytics/profiler.cpp
+    src/commandbuffer.cpp
+    src/components/actor.cpp
+    src/components/animationcontroller.cpp
+    src/components/baselight.cpp
+    src/components/basemesh.cpp
+    src/components/camera.cpp
+    src/components/component.cpp
+    src/components/directlight.cpp
+    src/components/nativebehaviour.cpp
+    src/components/particlerender.cpp
+    src/components/pointlight.cpp
+    src/components/spotlight.cpp
+    src/components/scene.cpp
+    src/components/spritemesh.cpp
+    src/components/staticmesh.cpp
+    src/components/textmesh.cpp
+    src/components/transform.cpp
+    src/engine.cpp
+    src/file.cpp
+    src/input.cpp
+    src/log.cpp
+    src/resources/animationclip.cpp
+    src/resources/atlas.cpp
+    src/resources/font.cpp
+    src/resources/material.cpp
+    src/resources/mesh.cpp
+    src/resources/particleeffect.cpp
+    src/resources/pipeline.cpp
+    src/resources/rendertexture.cpp
+    src/resources/text.cpp
+    src/resources/texture.cpp
+    src/timer.cpp
+    src/utils.cpp
+    includes/adapters/desktopadaptor.h
+    includes/adapters/iplatformadaptor.h
+    includes/adapters/androidfile.h
+    includes/adapters/mobileadaptor.h
+    includes/analytics/profiler.h
+    includes/commandbuffer.h
+    includes/components/actor.h
+    includes/components/animationcontroller.h
+    includes/components/baselight.h
+    includes/components/basemesh.h
+    includes/components/camera.h
+    includes/components/component.h
+    includes/components/directlight.h
+    includes/components/nativebehaviour.h
+    includes/components/particlerender.h
+    includes/components/pointlight.h
+    includes/components/spotlight.h
+    includes/components/scene.h
+    includes/components/spritemesh.h
+    includes/components/staticmesh.h
+    includes/components/textmesh.h
+    includes/components/transform.h
+    includes/engine.h
+    includes/file.h
+    includes/input.h
+    includes/log.h
+    includes/module.h
+    includes/platform.h
+    includes/resources/animationclip.h
+    includes/resources/atlas.h
+    includes/resources/font.h
+    includes/resources/material.h
+    includes/resources/mesh.h
+    includes/resources/particleeffect.h
+    includes/resources/pipeline.h
+    includes/resources/rendertexture.h
+    includes/resources/text.h
+    includes/resources/texture.h
+    includes/system.h
+    includes/timer.h
+    includes/utils.h
+)
+set(CONVERTER_FILES
+    src/converters/builder.cpp    
+    includes/converters/builder.h    
+    src/converters/converter.cpp
+    includes/converters/converter.h    
+)
+list(APPEND SRC_FILES src/adapters/desktopadaptor.cpp)
+add_library(engine STATIC ${SRC_FILES})
+target_include_directories(engine PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/includes includes/components includes/resources ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(engine PUBLIC next freetype glfw physfs Qt5::Core)
+target_compile_definitions(engine PUBLIC ENGINE_STATIC_DEFINE) # since both builds use engine_export, this marks the export/import macro as no-op
+set_target_properties(engine PROPERTIES AUTOMOC ON)
+add_library(engine-editor SHARED ${SRC_FILES} ${CONVERTER_FILES})
+set_target_properties(engine-editor PROPERTIES AUTOMOC ON)
+target_include_directories(engine-editor PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/includes includes/components includes/resources ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(engine-editor PUBLIC next-editor freetype-editor glfw-editor physfs-editor Qt5::Core)
+target_compile_definitions(engine-editor PRIVATE NEXT_SHARED) # using `next` library in shared form ( exposr dllimport's on windows)
+
+generate_export_header(engine-editor BASE_NAME engine)
+
+list(APPEND SRC_FILES ${CMAKE_CURRENT_BINARY_DIR}/engine_export.h)
+

--- a/engine/includes/analytics/profiler.h
+++ b/engine/includes/analytics/profiler.h
@@ -21,7 +21,7 @@
     #define PROFILER_RESET(x)
 #endif
 
-class NEXT_LIBRARY_EXPORT Profiler {
+class ENGINE_EXPORT Profiler {
 public:
     struct CallPoint {
         const char             *name;

--- a/engine/includes/commandbuffer.h
+++ b/engine/includes/commandbuffer.h
@@ -12,7 +12,7 @@ class MaterialInstance;
 
 typedef vector<RenderTexture *> TargetBuffer;
 
-class NEXT_LIBRARY_EXPORT ICommandBuffer: public Object {
+class ENGINE_EXPORT ICommandBuffer: public Object {
     A_REGISTER(ICommandBuffer, Object, System)
 
 public:

--- a/engine/includes/components/actor.h
+++ b/engine/includes/components/actor.h
@@ -8,7 +8,7 @@ class Component;
 class Transform;
 class Prefab;
 
-class NEXT_LIBRARY_EXPORT Actor : public Object {
+class ENGINE_EXPORT Actor : public Object {
     A_REGISTER(Actor, Object, Scene)
 
     A_PROPERTIES(

--- a/engine/includes/components/animationcontroller.h
+++ b/engine/includes/components/animationcontroller.h
@@ -6,7 +6,7 @@
 class PropertyAnimation;
 class AnimationClip;
 
-class NEXT_LIBRARY_EXPORT AnimationController : public NativeBehaviour {
+class ENGINE_EXPORT AnimationController : public NativeBehaviour {
     A_REGISTER(AnimationController, NativeBehaviour, Components)
 
     A_PROPERTIES (

--- a/engine/includes/components/baselight.h
+++ b/engine/includes/components/baselight.h
@@ -8,7 +8,7 @@
 class Mesh;
 class MaterialInstance;
 
-class NEXT_LIBRARY_EXPORT BaseLight : public NativeBehaviour {
+class ENGINE_EXPORT BaseLight : public NativeBehaviour {
     A_REGISTER(BaseLight, NativeBehaviour, Components)
 
     A_PROPERTIES(

--- a/engine/includes/components/basemesh.h
+++ b/engine/includes/components/basemesh.h
@@ -8,7 +8,7 @@
 
 #include <array>
 
-class NEXT_LIBRARY_EXPORT BaseMesh : public NativeBehaviour {
+class ENGINE_EXPORT BaseMesh : public NativeBehaviour {
     A_REGISTER(BaseMesh, NativeBehaviour, General);
 
     A_METHODS(

--- a/engine/includes/components/camera.h
+++ b/engine/includes/components/camera.h
@@ -7,7 +7,7 @@
 
 class Pipeline;
 
-class NEXT_LIBRARY_EXPORT Camera : public Component {
+class ENGINE_EXPORT Camera : public Component {
     A_REGISTER(Camera, Component, Components)
 
     A_PROPERTIES(

--- a/engine/includes/components/component.h
+++ b/engine/includes/components/component.h
@@ -6,7 +6,7 @@
 class Actor;
 class ICommandBuffer;
 
-class NEXT_LIBRARY_EXPORT Component : public Object {
+class ENGINE_EXPORT Component : public Object {
     A_REGISTER(Component, Object, General)
 
     A_PROPERTIES (

--- a/engine/includes/components/directlight.h
+++ b/engine/includes/components/directlight.h
@@ -6,7 +6,7 @@
 class Mesh;
 class MaterialInstance;
 
-class NEXT_LIBRARY_EXPORT DirectLight : public BaseLight {
+class ENGINE_EXPORT DirectLight : public BaseLight {
     A_REGISTER(DirectLight, BaseLight, Components)
 
     A_NOPROPERTIES()

--- a/engine/includes/components/nativebehaviour.h
+++ b/engine/includes/components/nativebehaviour.h
@@ -3,7 +3,7 @@
 
 #include "component.h"
 
-class NEXT_LIBRARY_EXPORT NativeBehaviour : public Component {
+class ENGINE_EXPORT NativeBehaviour : public Component {
     A_REGISTER(NativeBehaviour, Component, Components)
 
     A_NOPROPERTIES()

--- a/engine/includes/components/particlerender.h
+++ b/engine/includes/components/particlerender.h
@@ -6,7 +6,7 @@
 class ParticleRenderPrivate;
 class ParticleEffect;
 
-class NEXT_LIBRARY_EXPORT ParticleRender : public NativeBehaviour {
+class ENGINE_EXPORT ParticleRender : public NativeBehaviour {
     A_REGISTER(ParticleRender, NativeBehaviour, Components)
 
     A_PROPERTIES(

--- a/engine/includes/components/pointlight.h
+++ b/engine/includes/components/pointlight.h
@@ -6,7 +6,7 @@
 class Mesh;
 class MaterialInstance;
 
-class NEXT_LIBRARY_EXPORT PointLight : public BaseLight {
+class ENGINE_EXPORT PointLight : public BaseLight {
     A_REGISTER(PointLight, BaseLight, Components)
 
     A_PROPERTIES(

--- a/engine/includes/components/scene.h
+++ b/engine/includes/components/scene.h
@@ -3,7 +3,7 @@
 
 #include "engine.h"
 
-class NEXT_LIBRARY_EXPORT Scene : public Object {
+class ENGINE_EXPORT Scene : public Object {
     A_REGISTER(Scene, Object, General)
 
 public:

--- a/engine/includes/components/spotlight.h
+++ b/engine/includes/components/spotlight.h
@@ -6,7 +6,7 @@
 class Mesh;
 class MaterialInstance;
 
-class NEXT_LIBRARY_EXPORT SpotLight : public BaseLight {
+class ENGINE_EXPORT SpotLight : public BaseLight {
     A_REGISTER(SpotLight, BaseLight, Components)
 
     A_PROPERTIES(

--- a/engine/includes/components/spritemesh.h
+++ b/engine/includes/components/spritemesh.h
@@ -3,7 +3,7 @@
 
 #include "basemesh.h"
 
-class NEXT_LIBRARY_EXPORT SpriteMesh : public BaseMesh {
+class ENGINE_EXPORT SpriteMesh : public BaseMesh {
     A_REGISTER(SpriteMesh, BaseMesh, Components)
 
     A_PROPERTIES(

--- a/engine/includes/components/staticmesh.h
+++ b/engine/includes/components/staticmesh.h
@@ -3,7 +3,7 @@
 
 #include "basemesh.h"
 
-class NEXT_LIBRARY_EXPORT StaticMesh : public BaseMesh {
+class ENGINE_EXPORT StaticMesh : public BaseMesh {
     A_REGISTER(StaticMesh, BaseMesh, Components)
 
     A_PROPERTIES (

--- a/engine/includes/components/textmesh.h
+++ b/engine/includes/components/textmesh.h
@@ -8,7 +8,7 @@
 class Mesh;
 class MaterialInstance;
 
-class NEXT_LIBRARY_EXPORT TextMesh : public BaseMesh {
+class ENGINE_EXPORT TextMesh : public BaseMesh {
     A_REGISTER(TextMesh, BaseMesh, Components)
 
     A_PROPERTIES(

--- a/engine/includes/components/transform.h
+++ b/engine/includes/components/transform.h
@@ -3,7 +3,7 @@
 
 #include "component.h"
 
-class NEXT_LIBRARY_EXPORT Transform : public Component {
+class ENGINE_EXPORT Transform : public Component {
     A_REGISTER(Transform, Component, Components)
 
     A_PROPERTIES(

--- a/engine/includes/converters/builder.h
+++ b/engine/includes/converters/builder.h
@@ -1,5 +1,5 @@
-#ifndef BUILDER_H
-#define BUILDER_H
+#ifndef IBUILDER_H
+#define IBUILDER_H
 
 #include "converter.h"
 #include "resources/text.h"
@@ -10,7 +10,7 @@ class ProjectManager;
 
 typedef QMap<QString, QString>      StringMap;
 
-class NEXT_LIBRARY_EXPORT IBuilder : public IConverter {
+class ENGINE_EXPORT IBuilder : public IConverter {
     Q_OBJECT
 public:
     IBuilder                        ();

--- a/engine/includes/converters/converter.h
+++ b/engine/includes/converters/converter.h
@@ -5,7 +5,7 @@
 
 #include <engine.h>
 
-class NEXT_LIBRARY_EXPORT IConverterSettings {
+class ENGINE_EXPORT IConverterSettings {
 public:
     IConverterSettings              ();
     virtual ~IConverterSettings     () {}
@@ -49,7 +49,7 @@ protected:
     vector<string>          mSubItems;
 };
 
-class NEXT_LIBRARY_EXPORT IConverter : public QObject {
+class ENGINE_EXPORT IConverter : public QObject {
 public:
     enum ContentTypes {
         ContentInvalid              = MetaType::USERTYPE,

--- a/engine/includes/engine.h
+++ b/engine/includes/engine.h
@@ -1,13 +1,13 @@
 #ifndef ENGINE_H
 #define ENGINE_H
 
+#include "engine_export.h"
+
 #include <cstdint>
 #include <string>
 #include <map>
 
-#include "object.h"
 #include <objectsystem.h>
-
 #include <file.h>
 
 class IModule;
@@ -17,7 +17,7 @@ class EnginePrivate;
 class Actor;
 class Scene;
 
-class NEXT_LIBRARY_EXPORT Engine : public ObjectSystem {
+class ENGINE_EXPORT Engine : public ObjectSystem {
 public:
     Engine                      (IFile *file, int argc, char **argv);
     ~Engine                     ();

--- a/engine/includes/file.h
+++ b/engine/includes/file.h
@@ -24,7 +24,7 @@
 #include <string>
 #include <list>
 
-#include <global.h>
+#include "engine_export.h"
 
 using namespace std;
 
@@ -32,7 +32,7 @@ typedef void            _FILE;
 typedef	uint64_t        _size_t;
 typedef list<string>    StringList;
 
-class NEXT_LIBRARY_EXPORT IFile {
+class ENGINE_EXPORT IFile {
 public:
     void                finit           (const char *argv0);
     void                fsearchPathAdd  (const char *path, bool isFirst = false);

--- a/engine/includes/input.h
+++ b/engine/includes/input.h
@@ -7,7 +7,7 @@
 
 class IPlatformAdaptor;
 
-class NEXT_LIBRARY_EXPORT Input {
+class ENGINE_EXPORT Input {
 public:
     enum MouseButton {
         LEFT                = 0x01,

--- a/engine/includes/log.h
+++ b/engine/includes/log.h
@@ -9,7 +9,7 @@ class ILogHandler;
 
 class LogPrivate;
 
-class NEXT_LIBRARY_EXPORT Log {
+class ENGINE_EXPORT Log {
 public:
     enum LogTypes {
         ERR             = 0,

--- a/engine/includes/module.h
+++ b/engine/includes/module.h
@@ -14,7 +14,7 @@ class IConverter;
 #endif
 
 
-class NEXT_LIBRARY_EXPORT IModule {
+class ENGINE_EXPORT IModule {
 public:
     enum PluginTypes {
         SYSTEM                      = (1<<0),

--- a/engine/includes/resources/animationclip.h
+++ b/engine/includes/resources/animationclip.h
@@ -2,8 +2,9 @@
 #define ANIMATIONCLIP_H
 
 #include "variantanimation.h"
+#include "engine_export.h"
 
-class NEXT_LIBRARY_EXPORT AnimationClip : public Object {
+class ENGINE_EXPORT AnimationClip : public Object {
     A_REGISTER(AnimationClip, Object, Resources)
 
 public:

--- a/engine/includes/resources/atlas.h
+++ b/engine/includes/resources/atlas.h
@@ -4,7 +4,7 @@
 #include "engine.h"
 #include "texture.h"
 
-class NEXT_LIBRARY_EXPORT Atlas : public Object {
+class ENGINE_EXPORT Atlas : public Object {
     A_REGISTER(Atlas, Object, Resources)
 
 public:

--- a/engine/includes/resources/font.h
+++ b/engine/includes/resources/font.h
@@ -6,7 +6,7 @@
 
 class FT_FaceRec_;
 
-class NEXT_LIBRARY_EXPORT Font : public Atlas {
+class ENGINE_EXPORT Font : public Atlas {
     A_REGISTER(Font, Atlas, Resources)
 
 public:

--- a/engine/includes/resources/material.h
+++ b/engine/includes/resources/material.h
@@ -6,7 +6,7 @@
 
 class Material;
 
-class NEXT_LIBRARY_EXPORT MaterialInstance {
+class ENGINE_EXPORT MaterialInstance {
 public:
     struct Info {
         uint32_t                type;
@@ -46,7 +46,7 @@ protected:
     InfoMap                     m_Info;
 };
 
-class NEXT_LIBRARY_EXPORT Material : public Object {
+class ENGINE_EXPORT Material : public Object {
     A_REGISTER(Material, Object, Resources)
 
 public:

--- a/engine/includes/resources/mesh.h
+++ b/engine/includes/resources/mesh.h
@@ -12,7 +12,7 @@
 #include "engine.h"
 #include "material.h"
 
-class NEXT_LIBRARY_EXPORT Mesh : public Object {
+class ENGINE_EXPORT Mesh : public Object {
     A_REGISTER(Mesh, Object, Resources)
 
 public:

--- a/engine/includes/resources/particleeffect.h
+++ b/engine/includes/resources/particleeffect.h
@@ -11,7 +11,7 @@ class Mesh;
 class ParticleModificator;
 typedef deque<ParticleModificator *> ModifiersDeque;
 
-class NEXT_LIBRARY_EXPORT ParticleEffect : public Object {
+class ENGINE_EXPORT ParticleEffect : public Object {
     A_REGISTER(ParticleEffect, Object, Resources)
 public:
     enum ModificatorType {

--- a/engine/includes/resources/pipeline.h
+++ b/engine/includes/resources/pipeline.h
@@ -20,7 +20,7 @@ class MaterialInstance;
 class RenderTexture;
 class PostProcessor;
 
-class NEXT_LIBRARY_EXPORT Pipeline : public Object {
+class ENGINE_EXPORT Pipeline : public Object {
     A_REGISTER(Pipeline, Object, Resources)
 
 public:

--- a/engine/includes/resources/rendertexture.h
+++ b/engine/includes/resources/rendertexture.h
@@ -3,7 +3,7 @@
 
 #include "texture.h"
 
-class NEXT_LIBRARY_EXPORT RenderTexture : public Texture {
+class ENGINE_EXPORT RenderTexture : public Texture {
     A_REGISTER(RenderTexture, Texture, Resources)
 
 public:

--- a/engine/includes/resources/text.h
+++ b/engine/includes/resources/text.h
@@ -3,7 +3,7 @@
 
 #include "engine.h"
 
-class NEXT_LIBRARY_EXPORT Text : public Object {
+class ENGINE_EXPORT Text : public Object {
     A_REGISTER(Text, Object, Resources)
 
 public:

--- a/engine/includes/resources/texture.h
+++ b/engine/includes/resources/texture.h
@@ -7,7 +7,7 @@
 
 class Node;
 
-class NEXT_LIBRARY_EXPORT Texture : public Object {
+class ENGINE_EXPORT Texture : public Object {
     A_REGISTER(Texture, Object, Resources)
 
 public:

--- a/engine/includes/timer.h
+++ b/engine/includes/timer.h
@@ -7,7 +7,7 @@
 
 typedef std::chrono::high_resolution_clock::time_point  TimePoint;
 
-class NEXT_LIBRARY_EXPORT Timer {
+class ENGINE_EXPORT Timer {
 public:
     static void                 init                        (float fixed);
 

--- a/engine/includes/utils.h
+++ b/engine/includes/utils.h
@@ -3,7 +3,7 @@
 
 #include "engine.h"
 
-class NEXT_LIBRARY_EXPORT Utils {
+class ENGINE_EXPORT Utils {
 public:
     static string       wstringToUtf8           (const wstring &in);
 

--- a/engine/src/adapters/desktopadaptor.cpp
+++ b/engine/src/adapters/desktopadaptor.cpp
@@ -1,11 +1,11 @@
 #include "adapters/desktopadaptor.h"
-#if(_MSC_VER)
+#if(_WIN32)
     #include <windows.h>
     #include <Shlobj.h>
 #elif __APPLE__
     #include <CoreFoundation/CoreFoundation.h>
 #endif
-#if(__GNUC__)
+#if(__GNUC__ && !defined(_WIN32))
     #include <dlfcn.h>
 #endif
 #include <GLFW/glfw3.h>
@@ -14,6 +14,7 @@
 #include <file.h>
 #include <utils.h>
 
+#include <algorithm>
 #include <mutex>
 #include <string.h>
 
@@ -194,7 +195,7 @@ Vector2 DesktopAdaptor::joystickTriggers(uint8_t index) {
 }
 
 void *DesktopAdaptor::pluginLoad(const char *name) {
-#if(_MSC_VER)
+#if(_WIN32)
     return (void*)LoadLibrary((LPCWSTR)name);
 #elif(__GNUC__)
     return dlopen(name, RTLD_NOW);
@@ -202,7 +203,7 @@ void *DesktopAdaptor::pluginLoad(const char *name) {
 }
 
 bool DesktopAdaptor::pluginUnload(void *plugin) {
-#if(_MSC_VER)
+#if(_WIN32)
     return FreeLibrary((HINSTANCE)plugin);
 #elif(__GNUC__)
     return dlclose(plugin);
@@ -210,7 +211,7 @@ bool DesktopAdaptor::pluginUnload(void *plugin) {
 }
 
 void *DesktopAdaptor::pluginAddress(void *plugin, const string &name) {
-#if(_MSC_VER)
+#if(_WIN32)
     return (void*)GetProcAddress((HINSTANCE)plugin, name.c_str());
 #elif(__GNUC__)
     return dlsym(plugin, name.c_str());

--- a/engine/src/resources/texture.cpp
+++ b/engine/src/resources/texture.cpp
@@ -2,9 +2,7 @@
 
 #include <variant.h>
 
-#if __linux__
 #include <cstring>
-#endif
 
 #define HEADER  "Header"
 #define DATA    "Data"

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(renders)

--- a/modules/renders/CMakeLists.txt
+++ b/modules/renders/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(rendergl)

--- a/modules/renders/rendergl/CMakeLists.txt
+++ b/modules/renders/rendergl/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(SRC_FILES
+    src/commandbuffergl.cpp  src/postprocess/aambientocclusiongl.cpp  src/postprocess/abloomgl.cpp  src/renderglsystem.cpp         src/resources/ameshgl.cpp           src/resources/atexturegl.cpp
+    src/filters/ablurgl.cpp  src/postprocess/aantialiasinggl.cpp      src/rendergl.cpp              src/resources/amaterialgl.cpp  src/resources/arendertexturegl.cpp    
+)
+set(INC_FILES
+    includes/agl.h               includes/postprocess/aambientocclusiongl.h   includes/postprocess/apostprocessor.h   includes/resources/amaterialgl.h        includes/resources/atexturegl.h
+    includes/commandbuffergl.h   includes/postprocess/aantialiasinggl.h       includes/rendergl.h                     includes/resources/ameshgl.h
+    includes/filters/ablurgl.h   includes/postprocess/abloomgl.h              includes/renderglsystem.h               includes/resources/arendertexturegl.h    
+)
+add_library(rendergl STATIC ${SRC_FILES} ${INC_FILES})
+target_include_directories(rendergl PUBLIC includes)
+target_link_libraries(rendergl PUBLIC engine glad)
+
+add_library(rendergl-editor SHARED ${SRC_FILES} ${INC_FILES})
+target_include_directories(rendergl-editor PUBLIC includes)
+target_link_libraries(rendergl-editor PUBLIC engine-editor glad)
+target_compile_definitions(rendergl-editor PRIVATE NEXT_SHARED) # TODO: use cmake support for export header generation

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_subdirectory(angelscript)
+add_subdirectory(next)
+add_subdirectory(freetype)
+add_subdirectory(fbx)
+add_subdirectory(glad)
+add_subdirectory(glfw)
+add_subdirectory(glsl)
+add_subdirectory(spirvcross)
+add_subdirectory(zlib)
+add_subdirectory(quazip)
+
+add_subdirectory(physfs)

--- a/thirdparty/angelscript/CMakeLists.txt
+++ b/thirdparty/angelscript/CMakeLists.txt
@@ -1,0 +1,54 @@
+set(SRC_FILES
+    source/as_atomic.cpp
+    source/as_callfunc_ppc_64.cpp
+    source/as_callfunc_x86.cpp
+    source/as_gc.cpp
+    source/as_outputbuffer.cpp
+    source/as_scriptnode.cpp
+    source/as_typeinfo.cpp
+    source/as_builder.cpp
+    source/as_callfunc_ppc.cpp
+    source/as_callfunc_xenon.cpp
+    source/as_generic.cpp
+    source/as_parser.cpp
+    source/as_scriptobject.cpp
+    source/as_variablescope.cpp
+    source/as_bytecode.cpp
+    source/as_callfunc_sh4.cpp
+    source/as_compiler.cpp
+    source/as_globalproperty.cpp
+    source/as_restore.cpp
+    source/as_string.cpp
+    source/as_callfunc_arm.cpp
+    source/as_callfunc_x64_gcc.cpp
+    source/as_configgroup.cpp
+    source/as_memory.cpp
+    source/as_scriptcode.cpp
+    source/as_string_util.cpp
+    source/as_callfunc.cpp
+    source/as_callfunc_x64_mingw.cpp
+    source/as_context.cpp
+    source/as_module.cpp
+    source/as_scriptengine.cpp
+    source/as_thread.cpp
+    source/as_callfunc_mips.cpp
+    source/as_callfunc_x64_msvc.cpp
+    source/as_datatype.cpp
+    source/as_objecttype.cpp
+    source/as_scriptfunction.cpp
+    source/as_tokenizer.cpp    
+)
+
+add_library(angelscript
+    STATIC ${SRC_FILES})
+target_include_directories(angelscript PRIVATE include)
+target_compile_definitions(angelscript PUBLIC ANGELSCRIPT_EXPORT AS_NO_COMPILER)
+
+if (MSVC AND (CMAKE_SIZEOF_VOID_P EQUAL 8))
+    enable_language (ASM_MASM)
+	list(APPEND SRC_FILES source/as_callfunc_x64_msvc_asm.asm)
+endif()
+add_library(angelscript-editor
+    SHARED ${SRC_FILES})
+target_include_directories(angelscript-editor PRIVATE include)
+target_compile_definitions(angelscript-editor PUBLIC ANGELSCRIPT_EXPORT)

--- a/thirdparty/fbx/CMakeLists.txt
+++ b/thirdparty/fbx/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(fbx SHARED IMPORTED GLOBAL)
+
+target_include_directories(fbx INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+#target_compile_definitions(fbx INTERFACE FBXSDK_SHARED)
+if(WIN32)
+set_property(TARGET fbx PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/lib/libfbxsdk.dll)
+set_property(TARGET fbx PROPERTY IMPORTED_IMPLIB ${CMAKE_CURRENT_SOURCE_DIR}/lib/libfbxsdk.lib)
+elseif(APPLE)
+set_property(TARGET fbx PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/lib/libfbxsdk.dylib") 
+else()
+set_property(TARGET fbx PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/lib/libfbxsdk.so") 
+endif()

--- a/thirdparty/freetype/CMakeLists.txt
+++ b/thirdparty/freetype/CMakeLists.txt
@@ -1,0 +1,52 @@
+set(SRC_FILES
+        src/base/ftbase.c
+        src/base/ftinit.c
+        src/base/ftsystem.c
+        src/base/ftbbox.c
+        src/base/ftbdf.c
+        src/base/ftbitmap.c
+        src/base/ftcid.c
+        src/base/ftfntfmt.c
+        src/base/ftfstype.c
+        src/base/ftgasp.c
+        src/base/ftglyph.c
+        src/base/ftgxval.c
+        src/base/ftlcdfil.c
+        src/base/ftmm.c
+        src/base/ftotval.c
+        src/base/ftpatent.c
+        src/base/ftpfr.c
+        src/base/ftstroke.c
+        src/base/ftsynth.c
+        src/base/fttype1.c
+        src/base/ftwinfnt.c
+        src/autofit/autofit.c
+        src/bdf/bdf.c
+        src/cff/cff.c
+        src/cache/ftcache.c
+        src/gzip/ftgzip.c
+        src/lzw/ftlzw.c
+        src/pcf/pcf.c
+        src/pfr/pfr.c
+        src/psaux/psaux.c
+        src/pshinter/pshinter.c
+        src/psnames/psmodule.c
+        src/raster/raster.c
+        src/sfnt/sfnt.c
+        src/smooth/smooth.c
+        src/truetype/truetype.c
+        src/type1/type1.c
+        src/cid/type1cid.c
+        src/type42/type42.c
+        src/winfonts/winfnt.c
+
+)
+
+add_library(freetype
+    STATIC ${SRC_FILES})
+target_include_directories(freetype PUBLIC include)
+target_compile_definitions(freetype PRIVATE FT2_BUILD_LIBRARY)
+add_library(freetype-editor
+    SHARED ${SRC_FILES})
+target_include_directories(freetype-editor PUBLIC include)
+target_compile_definitions(freetype-editor PRIVATE FT2_BUILD_LIBRARY)

--- a/thirdparty/glad/CMakeLists.txt
+++ b/thirdparty/glad/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(SRC_FILES
+    src/glad.c
+)
+
+add_library(glad STATIC ${SRC_FILES})
+target_include_directories(glad PUBLIC include)

--- a/thirdparty/glfw/CMakeLists.txt
+++ b/thirdparty/glfw/CMakeLists.txt
@@ -1,0 +1,86 @@
+set(SRC_FILES
+    src/context.c
+    src/init.c
+    src/input.c
+    src/monitor.c
+    src/vulkan.c
+    src/window.c
+
+    src/internal.h
+    include/GLFW/glfw3.h
+    include/GLFW/glfw3native.h
+)
+if(WIN32)
+    list(APPEND SRC_FILES
+            src/win32_init.c
+            src/win32_joystick.c
+            src/win32_monitor.c
+            src/win32_time.c
+            src/win32_tls.c
+            src/win32_window.c
+            src/wgl_context.c
+            src/egl_context.c
+
+            src/win32_platform.h
+            src/win32_joystick.h
+            src/wgl_context.h
+            src/egl_context.h
+    )
+elseif(UNIX)
+    find_package(X11 REQUIRED)
+    list(APPEND SRC_FILES
+            src/x11_init.c
+            src/linux_joystick.c
+            src/xkb_unicode.c
+            src/x11_monitor.c
+            src/posix_time.c
+            src/posix_tls.c
+            src/x11_window.c
+            src/glx_context.c
+            src/egl_context.c
+
+            src/x11_platform.h
+            src/linux_joystick.h
+            src/glx_context.h
+            src/egl_context.h
+    )
+elseif(APPLE)
+    list(APPEND SRC_FILES
+            src/cocoa_init.m
+            src/cocoa_joystick.m
+            src/cocoa_monitor.m
+            src/cocoa_time.c
+            src/posix_tls.c
+            src/cocoa_window.m
+            src/nsgl_context.m
+
+            src/cocoa_platform.h
+            src/cocoa_joystick.h
+            src/nsgl_context.h
+    )
+endif()
+
+add_library(glfw
+    STATIC ${SRC_FILES})
+target_include_directories(glfw PUBLIC include)
+add_library(glfw-editor
+    SHARED ${SRC_FILES})
+target_include_directories(glfw-editor PUBLIC include)
+target_compile_definitions(glfw-editor PUBLIC _GLFW_BUILD_DLL)
+
+if(WIN32)
+    target_compile_definitions(glfw PUBLIC _GLFW_WIN32)
+    target_compile_definitions(glfw-editor PUBLIC _GLFW_WIN32)
+endif()
+if(UNIX)
+    target_compile_definitions(glfw PUBLIC _GLFW_X11)
+    target_compile_definitions(glfw-editor PUBLIC _GLFW_X11)
+    set(x11_libs 
+        ${X11_LIBRARIES} 
+        ${X11_Xrandr_LIB} 
+        ${X11_Xcursor_LIB}
+        ${X11_Xinerama_LIB}
+    )
+    target_link_libraries(glfw PUBLIC ${x11_libs} ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(glfw-editor PUBLIC ${x11_libs} ${CMAKE_THREAD_LIBS_INIT})
+endif()

--- a/thirdparty/glsl/CMakeLists.txt
+++ b/thirdparty/glsl/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_subdirectory(OGLCompilersDLL)
+add_subdirectory(SPIRV)
+add_subdirectory(glslang)
+
+add_library(glsl INTERFACE IMPORTED GLOBAL)
+target_link_libraries(glsl INTERFACE OGLCompiler SPIRV glslang ${CMAKE_THREAD_LIBS_INIT} )
+target_include_directories(glsl INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/thirdparty/glsl/glslang/CMakeLists.txt
+++ b/thirdparty/glsl/glslang/CMakeLists.txt
@@ -80,7 +80,7 @@ set(HEADERS
 #                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 # set(BISON_GLSLParser_OUTPUT_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/MachineIndependent/glslang_tab.cpp)
 
-glslang_pch(SOURCES MachineIndependent/pch.cpp)
+#glslang_pch(SOURCES MachineIndependent/pch.cpp)
 
 add_library(glslang ${LIB_TYPE} ${BISON_GLSLParser_OUTPUT_SOURCE} ${SOURCES} ${HEADERS})
 set_property(TARGET glslang PROPERTY FOLDER glslang)

--- a/thirdparty/next/CMakeLists.txt
+++ b/thirdparty/next/CMakeLists.txt
@@ -1,0 +1,27 @@
+set(SRC_FILES
+    src/core/bson.cpp   src/core/invalid.cpp  src/core/metamethod.cpp  src/core/metaproperty.cpp  src/core/object.cpp        src/core/threadpool.cpp  src/core/variant.cpp
+    src/core/event.cpp  src/core/json.cpp     src/core/metaobject.cpp  src/core/metatype.cpp      src/core/objectsystem.cpp  src/core/uri.cpp
+    
+    src/math/aabb.cpp  src/math/matrix3.cpp  src/math/obb.cpp    src/math/quaternion.cpp  src/math/vector2.cpp  src/math/vector4.cpp
+    src/math/math.cpp  src/math/matrix4.cpp  src/math/plane.cpp  src/math/ray.cpp         src/math/vector3.cpp
+    
+    src/anim/animation.cpp  src/anim/animationcurve.cpp  src/anim/propertyanimation.cpp  src/anim/variantanimation.cpp    
+)
+set(INC_FILES
+    inc/anim/animationcurve.h     inc/core/bson.h     inc/core/metamethod.h    inc/core/object.h        inc/core/variant.h  inc/math/matrix3.h  inc/math/quaternion.h  inc/math/vector4.h
+    inc/anim/animation.h          inc/core/event.h    inc/core/metaobject.h    inc/core/objectsystem.h  inc/global.h        inc/math/matrix4.h  inc/math/ray.h
+    inc/anim/propertyanimation.h  inc/core/invalid.h  inc/core/metaproperty.h  inc/core/threadpool.h    inc/math/aabb.h     inc/math/obb.h      inc/math/vector2.h
+    inc/anim/variantanimation.h   inc/core/json.h     inc/core/metatype.h      inc/core/uri.h           inc/math/amath.h    inc/math/plane.h    inc/math/vector3.h
+)
+add_library(next STATIC ${SRC_FILES} ${INC_FILES})
+target_include_directories(next PUBLIC inc)
+target_include_directories(next PUBLIC inc/core)
+target_include_directories(next PUBLIC inc/math)
+target_include_directories(next PUBLIC inc/anim)
+add_library(next-editor SHARED ${SRC_FILES} ${INC_FILES})
+target_include_directories(next-editor PUBLIC inc)
+target_include_directories(next-editor PUBLIC inc/core)
+target_include_directories(next-editor PUBLIC inc/math)
+target_include_directories(next-editor PUBLIC inc/anim)
+target_compile_definitions(next-editor PRIVATE NEXT_LIBRARY)
+target_compile_definitions(next-editor PUBLIC NEXT_SHARED)

--- a/thirdparty/physfs/CMakeLists.txt
+++ b/thirdparty/physfs/CMakeLists.txt
@@ -1,0 +1,43 @@
+set(SRC_FILES
+src/physfs_byteorder.c
+src/physfs.c
+src/archivers/dir.c
+src/archivers/grp.c
+src/archivers/hog.c
+src/archivers/mvl.c
+src/archivers/qpak.c
+src/archivers/wad.c
+src/archivers/zip.c
+src/acconfig.h
+src/physfs.h
+src/physfs_internal.h
+)
+if(WIN32)
+    list(APPEND SRC_FILES
+        src/platform/win32.c
+    )
+else()
+    list(APPEND SRC_FILES
+        src/platform/posix.c
+        src/platform/unix.c
+    )
+endif()
+add_library(physfs
+    STATIC ${SRC_FILES})
+add_library(physfs-editor
+    SHARED ${SRC_FILES})
+
+target_include_directories(physfs PUBLIC src)
+target_include_directories(physfs-editor PUBLIC src)
+target_link_libraries(physfs PUBLIC zlib)
+target_link_libraries(physfs-editor PUBLIC zlib)
+target_compile_definitions(physfs PUBLIC PHYSFS_SUPPORTS_ZIP PHYSFS_NO_CDROM_SUPPORT)
+target_compile_definitions(physfs-editor PUBLIC PHYSFS_SUPPORTS_ZIP PHYSFS_NO_CDROM_SUPPORT)
+if(APPLE)
+    target_compile_definitions(physfs PUBLIC PHYSFS_DARWIN)
+    target_compile_definitions(physfs-editor PUBLIC PHYSFS_DARWIN)
+endif()
+if(WIN32)
+    target_link_libraries(physfs PUBLIC advapi32)
+    target_link_libraries(physfs-editor PUBLIC advapi32)
+endif()

--- a/thirdparty/quazip/CMakeLists.txt
+++ b/thirdparty/quazip/CMakeLists.txt
@@ -1,0 +1,41 @@
+set(SRC_FILES
+src/unzip.c
+src/zip.c
+src/JlCompress.cpp
+src/qioapi.cpp
+src/quaadler32.cpp
+src/quacrc32.cpp
+src/quagzipfile.cpp
+src/quaziodevice.cpp
+src/quazip.cpp
+src/quazipdir.cpp
+src/quazipfile.cpp
+src/quazipfileinfo.cpp
+src/quazipnewinfo.cpp
+src/crypt.h
+src/ioapi.h
+src/JlCompress.h
+src/quaadler32.h
+src/quachecksum32.h
+src/quacrc32.h
+src/quagzipfile.h
+src/quaziodevice.h
+src/quazipdir.h
+src/quazipfile.h
+src/quazipfileinfo.h
+src/quazip_global.h
+src/quazip.h
+src/quazipnewinfo.h
+src/unzip.h
+src/zip.h
+)
+
+add_library(quazip STATIC ${SRC_FILES})
+target_include_directories(quazip PUBLIC src)
+target_link_libraries(quazip PUBLIC zlib Qt5::Core)
+set_target_properties(quazip PROPERTIES AUTOMOC ON)
+
+add_library(quazip-editor SHARED ${SRC_FILES})
+target_include_directories(quazip-editor PUBLIC src)
+target_link_libraries(quazip-editor PUBLIC zlib-editor Qt5::Core)
+set_target_properties(quazip-editor PROPERTIES AUTOMOC ON)

--- a/thirdparty/spirvcross/CMakeLists.txt
+++ b/thirdparty/spirvcross/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(SRC_FILES
+src/spirv_cfg.cpp  src/spirv_common.hpp  src/spirv_cross.hpp            src/spirv_cross_parsed_ir.hpp  src/spirv_glsl.hpp  src/spirv_hlsl.hpp  src/spirv_msl.cpp  src/spirv_parser.cpp
+src/spirv_cfg.hpp  src/spirv_cross.cpp   src/spirv_cross_parsed_ir.cpp  src/spirv_glsl.cpp             src/spirv_hlsl.cpp  src/spirv.hpp       src/spirv_msl.hpp  src/spirv_parser.hpp
+)
+
+add_library(spirvcross
+    STATIC ${SRC_FILES})
+target_include_directories(spirvcross PUBLIC src)

--- a/thirdparty/zlib/CMakeLists.txt
+++ b/thirdparty/zlib/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(SRC_FILES
+src/adler32.c  src/compress.c  src/crc32.c  src/deflate.c  src/gzio.c  src/infback.c  src/inffast.c  src/inflate.c  src/inftrees.c  src/trees.c  src/uncompr.c  src/zutil.c
+)
+
+add_library(zlib STATIC ${SRC_FILES})
+target_include_directories(zlib PUBLIC src)
+add_library(zlib-editor SHARED ${SRC_FILES})
+target_include_directories(zlib-editor PUBLIC src)

--- a/worldeditor/CMakeLists.txt
+++ b/worldeditor/CMakeLists.txt
@@ -1,0 +1,234 @@
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+set(SRC_FILES
+    
+    #    res/app-Info.plist
+    #    res/icon.rc
+    #    res/icons/thunder.icns
+        src/editors/componentbrowser/componentbrowser.ui
+        src/editors/contentbrowser/contentbrowser.ui
+        src/editors/contentbrowser/contentselect.ui
+        src/editors/materialedit/materialedit.ui
+        src/editors/meshedit/meshedit.ui
+        src/editors/meshedit/skeletalmeshedit.ui
+        src/editors/meshedit/staticmeshedit.ui
+        src/editors/objecthierarchy/hierarchybrowser.ui
+        src/editors/particleedit/particleedit.ui
+        src/editors/propertyedit/editors/Actions.ui
+        src/editors/propertyedit/editors/StringEdit.ui
+        src/editors/propertyedit/editors/VectorEdit.ui
+        src/editors/propertyedit/propertyeditor.ui
+        src/editors/scenecomposer/aboutdialog.ui
+        src/editors/scenecomposer/scenecomposer.ui
+        src/editors/textureedit/textureedit.ui
+        src/editors/timeline/timeline.ui
+        src/managers/asseteditormanager/importqueue.ui
+        src/managers/configmanager/configdialog.ui
+        src/managers/consolemanager/consolemanager.ui
+        src/managers/pluginmanager/plugindialog.ui
+        src/managers/projectmanager/projectdialog.ui
+    #    worldeditor.qbs
+
+    
+    res/WorldEditor.qrc
+    src/controllers/cameractrl.cpp
+    src/controllers/cameractrl.h
+    src/controllers/objectctrl.cpp
+    src/controllers/objectctrl.h
+    src/controllers/objectctrlpipeline.cpp
+    src/controllers/objectctrlpipeline.h
+    src/controllers/widgetctrl.cpp
+    src/controllers/widgetctrl.h
+    src/editors/componentbrowser/componentbrowser.cpp
+    src/editors/componentbrowser/componentbrowser.h
+    src/editors/componentbrowser/componentmodel.cpp
+    src/editors/componentbrowser/componentmodel.h
+    src/editors/contentbrowser/contentbrowser.cpp
+    src/editors/contentbrowser/contentbrowser.h
+    src/editors/contentbrowser/contentlist.cpp
+    src/editors/contentbrowser/contentlist.h
+    src/editors/contentbrowser/contentselect.cpp
+    src/editors/contentbrowser/contentselect.h
+    src/editors/contentbrowser/contenttree.cpp
+    src/editors/contentbrowser/contenttree.h
+    src/editors/materialedit/materialedit.cpp
+    src/editors/materialedit/materialedit.h
+    src/editors/meshedit/meshedit.cpp
+    src/editors/meshedit/meshedit.h
+    src/editors/objecthierarchy/hierarchybrowser.cpp
+    src/editors/objecthierarchy/hierarchybrowser.h
+    src/editors/objecthierarchy/objecthierarchymodel.cpp
+    src/editors/objecthierarchy/objecthierarchymodel.h
+    src/editors/particleedit/particleedit.cpp
+    src/editors/particleedit/particleedit.h
+    src/editors/propertyedit/custom/AssetProperty.cpp
+    src/editors/propertyedit/custom/AssetProperty.h
+    src/editors/propertyedit/custom/BoolProperty.cpp
+    src/editors/propertyedit/custom/BoolProperty.h
+    src/editors/propertyedit/custom/ColorProperty.cpp
+    src/editors/propertyedit/custom/ColorProperty.h
+    src/editors/propertyedit/custom/EnumProperty.cpp
+    src/editors/propertyedit/custom/EnumProperty.h
+    src/editors/propertyedit/custom/FilePathProperty.cpp
+    src/editors/propertyedit/custom/FilePathProperty.h
+    src/editors/propertyedit/custom/Property.cpp
+    src/editors/propertyedit/custom/Property.h
+    src/editors/propertyedit/custom/StringProperty.cpp
+    src/editors/propertyedit/custom/StringProperty.h
+    src/editors/propertyedit/custom/Vector3DProperty.cpp
+    src/editors/propertyedit/custom/Vector3DProperty.h
+    src/editors/propertyedit/editors/Actions.cpp
+    src/editors/propertyedit/editors/Actions.h
+    src/editors/propertyedit/editors/ArrayEdit.cpp
+    src/editors/propertyedit/editors/ArrayEdit.h
+    src/editors/propertyedit/editors/ColorEdit.cpp
+    src/editors/propertyedit/editors/ColorEdit.h
+    src/editors/propertyedit/editors/PathEdit.cpp
+    src/editors/propertyedit/editors/PathEdit.h
+    src/editors/propertyedit/editors/PathEdit.ui
+    src/editors/propertyedit/editors/StringEdit.cpp
+    src/editors/propertyedit/editors/StringEdit.h
+    src/editors/propertyedit/editors/VectorEdit.cpp
+    src/editors/propertyedit/editors/VectorEdit.h
+    src/editors/propertyedit/nextobject.cpp
+    src/editors/propertyedit/nextobject.h
+    src/editors/propertyedit/propertyeditor.cpp
+    src/editors/propertyedit/propertyeditor.h
+    src/editors/propertyedit/propertymodel.cpp
+    src/editors/propertyedit/propertymodel.h
+    src/editors/scemeeditor/schemeeditor.cpp
+    src/editors/scemeeditor/schemeeditor.h
+    src/editors/scenecomposer/aboutdialog.cpp
+    src/editors/scenecomposer/aboutdialog.h
+    src/editors/scenecomposer/scenecomposer.cpp
+    src/editors/scenecomposer/scenecomposer.h
+    src/editors/textureedit/textureedit.cpp
+    src/editors/textureedit/textureedit.h
+    src/editors/timeline/animationclipmodel.cpp
+    src/editors/timeline/animationclipmodel.h
+    src/editors/timeline/timeline.cpp
+    src/editors/timeline/timeline.h
+    src/graph/editors/chartview.cpp
+    src/graph/editors/chartview.h
+    src/graph/editors/curveeditor.cpp
+    src/graph/editors/curveeditor.h
+    src/graph/editors/graphwidget.cpp
+    src/graph/editors/graphwidget.h
+    src/graph/handles.cpp
+    src/graph/handles.h
+    src/graph/handletools.cpp
+    src/graph/handletools.h
+    src/graph/sceneview.cpp
+    src/graph/sceneview.h
+    src/graph/viewport.cpp
+    src/graph/viewport.h
+    src/main.cpp
+    src/managers/asseteditormanager/iconrender.cpp
+    src/managers/asseteditormanager/iconrender.h
+    src/managers/asseteditormanager/importqueue.cpp
+    src/managers/asseteditormanager/importqueue.h
+    src/managers/configmanager/configdialog.cpp
+    src/managers/configmanager/configdialog.h
+    src/managers/consolemanager/consolemanager.cpp
+    src/managers/consolemanager/consolemanager.h
+    src/managers/consolemanager/logmodel.cpp
+    src/managers/consolemanager/logmodel.h
+    src/managers/pluginmanager/plugindelegate.cpp
+    src/managers/pluginmanager/plugindelegate.h
+    src/managers/pluginmanager/plugindialog.cpp
+    src/managers/pluginmanager/plugindialog.h
+    src/managers/projectmanager/projectdialog.cpp
+    src/managers/projectmanager/projectdialog.h
+    src/managers/toolwindowmanager/private/qtoolwindowmanager_p.h
+    src/managers/toolwindowmanager/private/qtoolwindowmanagerarea_p.h
+    src/managers/toolwindowmanager/private/qtoolwindowmanagerwrapper_p.h
+    src/managers/toolwindowmanager/qabstracttoolwindowmanagerarea.cpp
+    src/managers/toolwindowmanager/qabstracttoolwindowmanagerarea.h
+    src/managers/toolwindowmanager/qtoolwindowmanager.cpp
+    src/managers/toolwindowmanager/qtoolwindowmanager.h
+    src/managers/toolwindowmanager/qtoolwindowmanagerarea.cpp
+    src/managers/toolwindowmanager/qtoolwindowmanagerwrapper.cpp
+    src/managers/undomanager/undomanager.cpp
+    src/managers/undomanager/undomanager.h
+    src/qlog.h
+    src/settings.cpp
+    src/settings.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/animconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/assetmanager.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/effectconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/fbxconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/fontconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/functionmodel.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/aconstvalue.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/acoordinates.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/agradient.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/amaterialparam.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/amathfunction.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/amathoperator.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/atexturesample.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/material/autils.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/materialconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/prefabconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/qbsbuilder.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/shaderbuilder.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/spirvconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/textconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include/textureconverter.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/animconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/assetmanager.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/effectconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/fbxconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/fontconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/functionmodel.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/materialconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/prefabconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/qbsbuilder.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/shaderbuilder.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/textconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/src/textureconverter.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/pluginmanager/include/pluginmodel.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/pluginmanager/src/pluginmodel.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/projectmanager/include/projectmanager.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/projectmanager/include/projectmodel.h
+    ${PROJECT_SOURCE_DIR}/develop/managers/projectmanager/src/projectmanager.cpp
+    ${PROJECT_SOURCE_DIR}/develop/managers/projectmanager/src/projectmodel.cpp
+    ${PROJECT_SOURCE_DIR}/develop/models/include/abstractschememodel.h
+    ${PROJECT_SOURCE_DIR}/develop/models/include/baseobjectmodel.h
+    ${PROJECT_SOURCE_DIR}/develop/models/src/baseobjectmodel.cpp
+   
+)
+add_executable(WorldEditor ${SRC_FILES})
+target_link_libraries(WorldEditor PRIVATE engine-editor rendergl-editor Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Quick Qt5::QuickWidgets fbx glsl spirvcross
+    zlib
+    )
+target_include_directories(WorldEditor PRIVATE src
+    ${PROJECT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/develop/managers/assetmanager/include
+    ${PROJECT_SOURCE_DIR}/develop/managers/projectmanager/include
+    ${PROJECT_SOURCE_DIR}/develop/managers/pluginmanager/include
+    ${PROJECT_SOURCE_DIR}/develop/models/include/
+    )
+file(READ ${PROJECT_SOURCE_DIR}/sponsors SPONSORS)
+file(READ ${PROJECT_SOURCE_DIR}/legal LEGAL)
+string(TIMESTAMP COPYRIGHT_YEAR "%Y")
+execute_process(
+  COMMAND git rev-parse --abbrev-ref HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_BRANCH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+target_compile_definitions(WorldEditor PUBLIC
+    -DCOMPANY_NAME="FrostSpear"
+    -DEDITOR_NAME="WorldEditor"
+    -DPRODUCT_NAME="Thunder Engine"
+    -DCOPYRIGHT_AUTHOR="Evgeniy Prikazchikov"
+    -DSPONSORS="${SPONSORS}"
+    -DCOPYRIGHT_YEAR="${COPYRIGHT_YEAR}"
+    -DLEGAL="${LEGAL}"
+    -DREVISION="${GIT_BRANCH}"
+    -DSDK_VERSION="1.0"
+#    LAUNCHER_VERSION = "1.0"
+#    YEAR = 2017
+    )


### PR DESCRIPTION
This was tested on following configurations: 
1. cmake generated sln files for Visual studio 2017  - 32bit
1. cmake generated sln files for Visual studio 2017  - 64bit *fbx linking problem*
1. using Linux+QtCreator 64bit
1. using Windows+QtCreator+Mingw530 *fbx linking problem*

Entries marked with "*fbx linking problem*" are usually a sign that fbxsdk libraries provided in third_party directory are incorrect ( 32bit vs 64bit or unsupported by mingw )
The list of changes:

* Use separate `ENGINE_EXPORT` macro for engine exports, instead of
reusing NEXT_LIBRARY_EXPORT.
* Fix includes ( in some places they could've been moved from a header
to associated cpp file, thus potentially reducing compile times )
* Replace some of `A` `OUT` etc. defines with `static constexpr const
char *`'s, since they've clashed with some headers ( A/OUT are use in
some places as template class names-> template<class A> )
* fix include guard duplication in converters/builder.h builder/builder.h
* change some ifdef guards from _MSC_VER to _WIN32 to halpe with MINGW
builds.

**NOTE** The build system is currently missing INSTALL target.
**NOTE2** The data files are not copied to output directory during build, so trying to run `./WorldEditor` results in 
```
qrc:/QML/qml/Emitters.qml:28: ReferenceError: effectModel is not defined
 [ FileIO ] Can't open file .embedded/DefaultSprite.mtl No such file or directory
 [ FileIO ] Can't open file .embedded/plane.fbx No such file or directory
 [ FileIO ] Can't open file .embedded/plane.fbx No such file or directory
 [ FileIO ] Can't open file .embedded/DirectLight.mtl No such file or directory
```
Related to #149 