### PR TITLE
Fix #199 missing libraries under Linux

### DIFF
--- a/build/install.qbs
+++ b/build/install.qbs
@@ -212,7 +212,24 @@ Product {
             "../thirdparty/fbx/lib/libfbxsdk" + suffix
         ]
         qbs.install: true
+        Properties {
+            condition: qbs.targetOS.contains("linux")
+            qbs.installDir: install.LIB_PATH + "/" + install.bundle
+        }
         qbs.installDir: install.BIN_PATH + "/" + install.bundle
+        qbs.installPrefix: install.PREFIX
+    }
+
+    Group {
+        name: "ICU Binaries"
+        condition: qbs.targetOS.contains("linux")
+        files: [
+            "/usr/lib/libicui18n.so.*",
+            "/usr/lib/libicuuc.so.*",
+            "/usr/lib/libicudata.so.*"
+        ]
+        qbs.install: true
+        qbs.installDir: install.LIB_PATH + "/" + install.bundle
         qbs.installPrefix: install.PREFIX
     }
 

--- a/modules/media/media.qbs
+++ b/modules/media/media.qbs
@@ -50,7 +50,6 @@ Project {
         cpp.cxxLanguageVersion: "c++14"
         cpp.minimumMacosVersion: "10.12"
         cpp.cxxStandardLibrary: "libc++"
-        cpp.sonamePrefix: "@executable_path"
 
         Properties {
             condition: qbs.targetOS.contains("windows")
@@ -61,6 +60,7 @@ Project {
         Properties {
             condition: qbs.targetOS.contains("darwin")
             cpp.weakFrameworks: ["OpenAL"]
+            cpp.sonamePrefix: "@executable_path"
         }
 
         Group {

--- a/modules/physics/bullet/bullet.qbs
+++ b/modules/physics/bullet/bullet.qbs
@@ -47,7 +47,6 @@ Project {
         cpp.cxxLanguageVersion: "c++14"
         cpp.minimumMacosVersion: "10.12"
         cpp.cxxStandardLibrary: "libc++"
-        cpp.sonamePrefix: "@executable_path"
 
         Properties {
             condition: qbs.targetOS.contains("windows")
@@ -55,6 +54,7 @@ Project {
 
         Properties {
             condition: qbs.targetOS.contains("darwin")
+            cpp.sonamePrefix: "@executable_path"
         }
 
         Group {

--- a/modules/renders/rendergl/rendergl.qbs
+++ b/modules/renders/rendergl/rendergl.qbs
@@ -43,7 +43,6 @@ Project {
         cpp.cxxLanguageVersion: "c++14"
         cpp.minimumMacosVersion: "10.12"
         cpp.cxxStandardLibrary: "libc++"
-        cpp.sonamePrefix: "@executable_path"
 
         Properties {
             condition: qbs.targetOS.contains("windows")
@@ -52,6 +51,7 @@ Project {
         Properties {
             condition: qbs.targetOS.contains("darwin")
             cpp.weakFrameworks: ["OpenGL"]
+            cpp.sonamePrefix: "@executable_path"
         }
 
         Group {

--- a/modules/vms/angel/angel.qbs
+++ b/modules/vms/angel/angel.qbs
@@ -51,7 +51,6 @@ Project {
         cpp.cxxLanguageVersion: "c++14"
         cpp.minimumMacosVersion: "10.12"
         cpp.cxxStandardLibrary: "libc++"
-        cpp.sonamePrefix: "@executable_path"
 
         Properties {
             condition: qbs.targetOS.contains("windows")
@@ -59,6 +58,7 @@ Project {
 
         Properties {
             condition: qbs.targetOS.contains("darwin")
+            cpp.sonamePrefix: "@executable_path"
         }
 
         Group {

--- a/thirdparty/libogg/ogg.qbs
+++ b/thirdparty/libogg/ogg.qbs
@@ -23,11 +23,15 @@ Project {
         cpp.includePaths: ogg.incPaths
         cpp.libraryPaths: [ ]
         cpp.dynamicLibraries: [ ]
-        cpp.sonamePrefix: "@executable_path"
 
         Properties {
             condition: qbs.targetOS.contains("windows")
             cpp.linkerFlags: ["/DEF:" + path + "/src/ogg.def"]
+        }
+
+        Properties {
+            condition: qbs.targetOS.contains("darwin")
+            cpp.sonamePrefix: "@executable_path"
         }
 
         Group {

--- a/thirdparty/libvorbis/vorbis.qbs
+++ b/thirdparty/libvorbis/vorbis.qbs
@@ -45,11 +45,15 @@ Project {
         cpp.includePaths: vorbis.incPaths
         cpp.libraryPaths: [ ]
         cpp.dynamicLibraries: [ ]
-        cpp.sonamePrefix: "@executable_path"
 
         Properties {
             condition: qbs.targetOS.contains("windows")
             cpp.linkerFlags: ["/DEF:" + path + "/src/vorbis.def"]
+        }
+
+        Properties {
+            condition: qbs.targetOS.contains("darwin")
+            cpp.sonamePrefix: "@executable_path"
         }
 
         Group {
@@ -96,11 +100,15 @@ Project {
         cpp.includePaths: vorbis.incPaths
         cpp.libraryPaths: [ ]
         cpp.dynamicLibraries: [ ]
-        cpp.sonamePrefix: "@executable_path"
 
         Properties {
             condition: qbs.targetOS.contains("windows")
             cpp.linkerFlags: ["/DEF:" + path + "/src/vorbisfile.def"]
+        }
+
+        Properties {
+            condition: qbs.targetOS.contains("darwin")
+            cpp.sonamePrefix: "@executable_path"
         }
 
         Group {


### PR DESCRIPTION
Fix the RPATH of the executables, copy the *-editor.so libraries to the lib folder, copy system ICU libraries to the install dir lib. #199